### PR TITLE
Refactor binary_search function from recursive to iterative

### DIFF
--- a/ahmia/ahmia/spiders/base.py
+++ b/ahmia/ahmia/spiders/base.py
@@ -75,17 +75,20 @@ class WebSpider(CrawlSpider):
 
     def build_links(self):
         """ Build a complete list of links from html in elasticsearch """
-        def binary_search(array, key, low, high):
-            """ Fast search in a sorted array """
-            if low > high:  # termination case
-                return -1
-            middle = (low + high) / 2  # gets the middle of the array
-            if array[middle] == key:   # if the middle is our key
-                return middle
-            elif key < array[middle]:  # our key might be in the left sub-array
-                return binary_search(array, key, low, middle-1)
-            else:                      # our key might be in the right sub-array
-                return binary_search(array, key, middle+1, high)
+        def binary_search(array, key):
+            """Fast search in a sorted array using iteration"""
+            lo = 0
+            hi = len(array) - 1
+
+            while lo <= hi:
+                middle = (lo + hi) // 2
+                if array[middle] == key:
+                    return middle
+                elif array[middle] > key:
+                    hi = middle - 1
+                else:
+                    lo = middle + 1
+            return -1
 
         es_obj = ElasticSearchPipeline.from_crawler(self.crawler).es
         new_links = []
@@ -126,7 +129,7 @@ class WebSpider(CrawlSpider):
                 response = HtmlResponse(url, body=content)
                 for request in self._requests_to_follow(response):
                     hash_target = hashlib.sha1(request.url.encode('utf-8')).hexdigest()
-                    if binary_search(hashes, hash_target, 0, len(hashes)-1) < 0:
+                    if binary_search(hashes, hash_target) < 0:
                         continue
                     new_links.append((id_,
                                       hash_target))


### PR DESCRIPTION
Reasons:

-   Since are overheads when calling functions recursively, making binary_search function iterative would improve performance.
-  Can avoid stack overflow problem if this function is changed to iterative function.
- Can eliminate redundant parameter.